### PR TITLE
Add tests to controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This is a simple TODO app that I am building to learn Ruby on Rails, and to get 
   - [x] Confirm deletion
 - [x] Search by columns
 - [x] Sort by columns
-- [ ] Add tests
+- [x] Add tests
   - [x] Models
   - [x] Services
   - [x] Channels
-  - [ ] Controllers
+  - [x] Controllers
 
 ## Technologies
 
@@ -39,4 +39,3 @@ This is a simple TODO app that I am building to learn Ruby on Rails, and to get 
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
-

--- a/spec/controllers/todo_controller_spec.rb
+++ b/spec/controllers/todo_controller_spec.rb
@@ -96,4 +96,25 @@ RSpec.describe TodosController, type: :controller do
       end.to have_broadcasted_to("todo_channel_#{user.id}").from_channel(TodoChannel)
     end
   end
+
+  describe 'GET #confirm_delete' do
+    it 'returns http success', js: true do
+      get :confirm_delete, params: { id: create(:todo, user_id: user.id).id }, format: :js
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'GET #inline' do
+    it 'returns http success', js: true do
+      get :inline, params: { id: create(:todo, user_id: user.id).id, field: 'title' }, format: :js
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'GET #more' do
+    it 'returns http success', js: true do
+      get :more, params: { id: create(:todo, user_id: user.id).id }, format: :js
+      expect(response).to have_http_status(:success)
+    end
+  end
 end


### PR DESCRIPTION
Add tests for missing actions in `TodosController` and update `README.md`.

* Add tests for `confirm_delete`, `inline`, and `more` actions in `spec/controllers/todo_controller_spec.rb`.
* Update `README.md` to indicate that controller tests are fully implemented.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nemuba/todo-ajax-rails/pull/3?shareId=a5a88209-5cab-43f7-9da4-f21de759df75).